### PR TITLE
Add instructions for generating MPCORB data

### DIFF
--- a/DATA_PREPARATION.md
+++ b/DATA_PREPARATION.md
@@ -1,0 +1,28 @@
+# Data Preparation
+
+This repository relies on some additional data files that are not distributed with the code.  The most important is `mpcorb_df.pkl`, a pandas DataFrame containing orbital elements for known minor planets.
+
+## Generating `mpcorb_df.pkl`
+
+1. **Download the MPCORB catalogue**
+
+   Visit the [Minor Planet Center MPCORB page](https://minorplanetcenter.net/iau/MPCORB.html) and download the latest `MPCORB.DAT.gz` file.  After downloading, decompress it so that you have `MPCORB.DAT` on disk.
+
+2. **Convert to a DataFrame**
+
+   Use the `skyfield` utilities to parse the file and save the result as a pickle:
+
+   ```python
+   from skyfield.data import mpc
+   import pandas as pd
+
+   df = mpc.load_mpcorb_dataframe('MPCORB.DAT')
+   df.to_pickle('GUIs/Utilities/mpcorb_df.pkl')
+   ```
+
+   The resulting `mpcorb_df.pkl` should be placed in `GUIs/Utilities` so that modules like `quick_eph_window.py` can load it.
+
+3. **Updating the file**
+
+   Periodically refresh the file by repeating the steps above with a newer `MPCORB.DAT`.
+

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ entry point is a simple launcher window that opens the available tools.
 
 ## Data files
 
-Some modules expect a pre-generated Minor Planet Center database in
-`GUIs/Utilities/mpcorb_df.pkl`.  If this file is not present, download the
-`mpcorb.dat` catalogue from the MPC and convert it into a pandas DataFrame saved
-at this location.
+Several tools depend on a pickled catalogue of minor planet orbits named
+`GUIs/Utilities/mpcorb_df.pkl`.  This file is not included in the repository.
+See [DATA_PREPARATION.md](DATA_PREPARATION.md) for instructions on downloading
+the MPCORB catalogue from the Minor Planet Center and generating the pickle.
 
 ## Running
 


### PR DESCRIPTION
## Summary
- add a detailed data preparation guide describing how to generate `mpcorb_df.pkl`
- reference the new guide from the main README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685ad07b21f48322923c9e64cabaf79a