### PR TITLE
Fix README typos and update paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Asteroid-Detection
 
-Toolkit created as part of an MSc thesis on automatic asteroid detection.
-The repository contains a set of graphical utilities for analysing FITS
-images, tracking known asteroids and plate solving observations.
+Toolkit created as part of an MSc thesis on automatic asteroid detection. The repository contains a set of graphical utilities for analysing FITS images, tracking known asteroids and plate solving observations.
 
 ## Requirements
 
@@ -11,9 +9,8 @@ images, tracking known asteroids and plate solving observations.
 - **Dependencies** (installable with `pip`):
   `astropy`, `astroquery`, `pandas`, `skyfield`, `matplotlib`, `customtkinter`,
   `Pillow`, `requests` and optionally `pwi4_client` for telescope control.
-- **Plate Solving** can use either `astroquery.astrometry_net` with an Astrometry.net
-  API key which needs to be added directly to the code in 'GUIs/Utilittes/ps_API.py' 'line 23' or a local installation of `astrometry.net`.
-- **Track Asteroid** requires the astreroid pikled files. see  [DATA_PREPARATION.md](DATA_PREPARATION.md)
+- **Plate Solving** can use either `astroquery.astrometry_net` with an Astrometry.net API key (add it to `GUIs/Utilities/ps_API.py` line 23) or a local installation of `astrometry.net`.
+- **Track Asteroid** requires the asteroid pickled files. See [DATA_PREPARATION.md](DATA_PREPARATION.md).
 
 ### Installation
 
@@ -27,11 +24,8 @@ images, tracking known asteroids and plate solving observations.
 
 ## Data files
 
-Several tools depend on a pickled catalogue of minor planet orbits named
-`GUIs/Utilities/mpcorb_df.pkl` and others.  This file is not included in the repository.
-See [DATA_PREPARATION.md](DATA_PREPARATION.md) for instructions on downloading
-the MPCORB catalogue from the Minor Planet Center and generating the pickle.
-
+Several tools depend on a pickled catalogue of minor planet orbits named `GUIs/Utilities/mpcorb_df.pkl` and others. This file is not included in the repository.
+See [DATA_PREPARATION.md](DATA_PREPARATION.md) for instructions on downloading the MPCORB catalogue from the Minor Planet Center and generating the pickle.
 ## Running
 
 Launch the application by running inside the GUIs folder:


### PR DESCRIPTION
## Summary
- fix minor typos in README
- update `ps_API` path
- clean up wrapped lines

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685c1bd482ec83228092cd10a09e4946